### PR TITLE
HOCS-2496 Toolbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IntelliJ IDEA
+.idea
+*.iml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBE_NAMESPACE=${ENVIRONMENT}
+export KUBE_SERVER=${KUBE_SERVER}
+export KUBE_TOKEN=${KUBE_TOKEN}
+export REPLICAS="1"
+export AWS_ACCOUNT_ID="449472082214"
+export CLUSTER_NAME="acp-notprod"
+
+if [[${KUBE_NAMESPACE} != "hocs-delta" &&
+     ${KUBE_NAMESPACE} != "hocs-gamma" &&
+     ${KUBE_NAMESPACE} != "hocs-qax"]]; then
+    echo "Can only deploy to hocs-delta, hocs-gamma or hocs-qax" > /dev/termination-log;
+    exit 1;
+fi
+
+echo
+echo "Deploying toolbox to ${ENVIRONMENT}"
+echo
+
+export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/${CLUSTER_NAME}.crt"
+
+kd --timeout 10m \
+    -f ./kube/hocs-toolbox.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ export VALID_NAMESPACES=("hocs-gamma" "hocs-delta" "hocs-qax")
 if [[ ${VALID_NAMESPACES[*]} =~ $KUBE_NAMESPACE ]] ; then
    echo "Passed namespace check"
 else
-   echo "Can only echo to ${VALID_NAMESPACES[@]}" | tee /dev/termination-log;
+   echo "Can only deploy to ${VALID_NAMESPACES[@]}" | tee /dev/termination-log;
    exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
-export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export REPLICAS="1"
 export AWS_ACCOUNT_ID="449472082214"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ export KUBE_TOKEN=${KUBE_TOKEN}
 export REPLICAS="1"
 export AWS_ACCOUNT_ID="449472082214"
 export CLUSTER_NAME="acp-notprod"
+export KUBE_SERVER="https://kube-api-notprod.notprod.acp.homeoffice.gov.uk"
 
 export VALID_NAMESPACES=("hocs-gamma" "hocs-delta" "hocs-qax")
 if [[ ${VALID_NAMESPACES[*]} =~ $KUBE_NAMESPACE ]] ; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,11 +8,12 @@ export REPLICAS="1"
 export AWS_ACCOUNT_ID="449472082214"
 export CLUSTER_NAME="acp-notprod"
 
-if [[${KUBE_NAMESPACE} != "hocs-delta" &&
-     ${KUBE_NAMESPACE} != "hocs-gamma" &&
-     ${KUBE_NAMESPACE} != "hocs-qax"]]; then
-    echo "Can only deploy to hocs-delta, hocs-gamma or hocs-qax" > /dev/termination-log;
-    exit 1;
+export VALID_NAMESPACES=("hocs-gamma" "hocs-delta" "hocs-qax")
+if [[ ${VALID_NAMESPACES[*]} =~ $KUBE_NAMESPACE ]] ; then
+   echo "Passed namespace check"
+else
+   echo "Can only echo to ${VALID_NAMESPACES[@]}" | tee /dev/termination-log;
+   exit 1
 fi
 
 echo

--- a/drone.yaml
+++ b/drone.yaml
@@ -3,6 +3,13 @@ kind: pipeline
 type: kubernetes
 name: build
 
+trigger:
+    target:
+      include:
+        - hocs-delta
+        - hocs-gamma
+        - hocs-qax
+        
 steps:
   when:
     target:

--- a/drone.yaml
+++ b/drone.yaml
@@ -11,13 +11,6 @@ trigger:
         - hocs-qax
         
 steps:
-  when:
-    target:
-      include:
-        - "hocs-delta"
-        - "hocs-gamma"
-        - "hocs-qax"
-
   - name: deploy to not-prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:

--- a/drone.yaml
+++ b/drone.yaml
@@ -4,19 +4,21 @@ type: kubernetes
 name: build
 
 steps:
+  when:
+    target:
+      include:
+        - "hocs-delta"
+        - "hocs-gamma"
+        - "hocs-qax"
+
   - name: deploy to not-prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:
       ENVIRONMENT: ${DRONE_DEPLOY_TO}
-      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      KUBE_SERVER: ${KUBE_SERVER{}}
       KUBE_TOKEN:
         from_secret: ${DRONE_DEPLOY_TO/-/_}
     commands:
       - ./deploy.sh
-    when:
-      event: promote
-      target:
-        include:
-          - "hocs-delta"
-          - "hocs-gamma"
-          - "hocs-qax"
+      when:
+        event: promote

--- a/drone.yaml
+++ b/drone.yaml
@@ -16,8 +16,7 @@ steps:
     when:
       event: promote
       target:
-        exclude:
-          - "*-dev"
-          - "*-qa"
-          - "*-demo"
-          - "*-prod"
+        include:
+          - "hocs-delta"
+          - "hocs-gamma"
+          - "hocs-qax"

--- a/drone.yaml
+++ b/drone.yaml
@@ -1,0 +1,23 @@
+---
+kind: pipeline
+type: kubernetes
+name: build
+
+steps:
+  - name: deploy to not-prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      KUBE_TOKEN:
+        from_secret: ${DRONE_DEPLOY_TO/-/_}
+    commands:
+      - ./deploy.sh
+    when:
+      event: promote
+      target:
+        exclude:
+          - "*-dev"
+          - "*-qa"
+          - "*-demo"
+          - "*-prod"

--- a/drone.yaml
+++ b/drone.yaml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: kubernetes
-name: build
+name: deploy
 
 trigger:
     target:

--- a/kube/hocs-toolbox.yaml
+++ b/kube/hocs-toolbox.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hocs-toolbox
   labels:
     version: {{.VERSION}}
+  annotations:
+    downscaler/downtime: 'Mon-Fri 18:00-08:00 Europe/London'
 spec:
   replicas: {{.REPLICAS}}
   selector:

--- a/kube/hocs-toolbox.yaml
+++ b/kube/hocs-toolbox.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hocs-toolbox
+  labels:
+    version: {{.VERSION}}
+spec:
+  replicas: {{.REPLICAS}}
+  selector:
+    matchLabels:
+      name: hocs-toolbox
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: hocs-toolbox
+        role: hocs-backend
+        version: {{.VERSION}}
+    spec:
+      containers:
+        - name: hocs-toolbox-query
+          image: 'docker.digital.homeoffice.gov.uk/hocs-psql-exec:build-50'
+          env:
+            - name: MODE
+              value: query
+            - name: HOCS_DB_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: endpoint
+            - name: HOCS_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: port
+            - name: HOCS_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: db_name
+            - name: HOCS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: username
+            - name: HOCS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: password
+            - name: HOCS_INFO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: info_username
+            - name: HOCS_INFO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds
+                  key: info_password
+            - name: HOCS_AUDIT_DB_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: endpoint
+            - name: HOCS_AUDIT_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: db_name
+            - name: HOCS_DOCS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_user
+            - name: HOCS_DOCS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-docs
+                  key: rds_password
+            - name: HOCS_CASEWORK_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-casework
+                  key: rds_user
+            - name: HOCS_CASEWORK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-casework
+                  key: rds_password
+            - name: HOCS_WORKFLOW_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-workflow
+                  key: rds_user
+            - name: HOCS_WORKFLOW_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-workflow
+                  key: rds_password
+            - name: HOCS_AUDIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_user
+            - name: HOCS_AUDIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_password
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+            runAsNonRoot: true
+            procMount: Default
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      imagePullSecrets:
+        - name: registry-credentials
+      schedulerName: default-scheduler


### PR DESCRIPTION
The toolbox is the base for all tools (scripts) that clear a namespaces.
This commit includes the following:
- the deploy script which filters releases to hocs-qax, hocs-delta and hocs-gamma
- the drone yaml for executing the deployment on kubernetes
- the toolbox deployment yaml