### PR TITLE
HOCS-2239: update downscaler annotation

### DIFF
--- a/kube/hocs-toolbox.yaml
+++ b/kube/hocs-toolbox.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     version: {{.VERSION}}
   annotations:
-    downscaler/downtime: 'Mon-Fri 18:00-08:00 Europe/London'
+    downscaler/downscale-period: 'Mon-Fri 18:00-08:00 Europe/London'
 spec:
   replicas: {{.REPLICAS}}
   selector:


### PR DESCRIPTION
Change the downscale annotation to use the `downscaler-period` 
option of downscaler. (https://codeberg.org/hjacobs/kube-downscaler)
This should allow for the pod to be downscaled and not brought back up the next day unless it is manually scaled up.